### PR TITLE
fix: install ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-# build stage
-FROM golang:alpine AS build-env
+FROM golang:alpine3.8 AS build-stage
 RUN mkdir /src
 WORKDIR /src
 ADD . .
 RUN go build -o falcosidekick
 
-# final stage
-FROM alpine
+FROM alpine:3.8 AS final-stage
+RUN apk add --no-cache ca-certificates
 RUN mkdir /app
 WORKDIR /app
 COPY --from=build-env /src/falcosidekick .


### PR DESCRIPTION
Install ca-certificates and pin alpine versions to 3.8 in order to guarantee a deterministic behaviour.
With the ca-certificates you avoid errors like the following one when trying to reach Slack:
```
2018/10/09 20:39:29 [ERROR] : (Slack) Post https://hooks.slack.com/services/<redacted>: x509: certificate signed by unknown authority
```