### PR TITLE
1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 1.0.2 - 2018-10-10
+### Added
+- new Slack Options `SLACK_FOOTER`, `SLACK_ICON`
+- check of `LISTEN_PORT` in `init()` : port is an integer between 1 and 65535
+- Add output status in log to get those which are enabled
+### Fixed
+-  add some log level tags
+
+## 1.0.1 - 2018-10-10
+- First tagged release

--- a/main.go
+++ b/main.go
@@ -4,17 +4,33 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 )
 
 // Env variables
 var port string
 
 func init() {
-
-	port, _ = os.LookupEnv("LISTEN_PORT")
-	if port == "" {
-		port = "2801"
+	port = "2801"
+	if lport, err := strconv.Atoi(os.Getenv("LISTEN_PORT")); err == nil {
+		if lport > 0 && lport < 65536 {
+			port = os.Getenv("LISTEN_PORT")
+		} else {
+			log.Fatalf("[ERROR] : Bad port number\n")
+		}
 	}
+	configText := "[INFO] : Outputs configuration : "
+	if os.Getenv("SLACK_TOKEN") != "" {
+		configText += "Slack=enabled, "
+	} else {
+		configText += "Slack=disabled, "
+	}
+	if os.Getenv("DATADOG_TOKEN") != "" {
+		configText += "Datadog=enabled"
+	} else {
+		configText += "Datadog=disabled"
+	}
+	log.Printf("%v\n", configText)
 }
 
 func main() {
@@ -22,7 +38,7 @@ func main() {
 	http.HandleFunc("/ping", pingHandler)
 	http.HandleFunc("/checkpayload", checkpayloadHandler)
 
-	log.Printf("Falco Sidekick is up and listening on port %v\n", port)
+	log.Printf("[INFO] : Falco Sidekick is up and listening on port %v\n", port)
 	if err := http.ListenAndServe(":"+port, nil); err != nil {
 		log.Fatalf("[ERROR] : %v\n", err.Error())
 	}

--- a/outputs/slack.go
+++ b/outputs/slack.go
@@ -45,7 +45,11 @@ func newSlackPayload(falcopayload types.FalcoPayload) slackPayload {
 		case string:
 			field.Title = i
 			field.Value = j.(string)
-			field.Short = true
+			if len([]rune(j.(string))) < 36 {
+				field.Short = true
+			} else {
+				field.Short = false
+			}
 		}
 		fields = append(fields, field)
 	}
@@ -66,7 +70,11 @@ func newSlackPayload(falcopayload types.FalcoPayload) slackPayload {
 	attachment.Fallback = falcopayload.Output
 	attachment.Fields = fields
 	attachment.PreText = falcopayload.Output
-	attachment.Footer = "https://github.com/Issif/falcosidekick"
+	if os.Getenv("SLACK_FOOTER") != "" {
+		attachment.Footer = os.Getenv("SLACK_FOOTER")
+	} else {
+		attachment.Footer = "https://github.com/Issif/falcosidekick"
+	}
 
 	var color string
 	switch falcopayload.Priority {
@@ -91,9 +99,16 @@ func newSlackPayload(falcopayload types.FalcoPayload) slackPayload {
 
 	attachments = append(attachments, attachment)
 
+	var iconUrl string
+	if os.Getenv("SLACK_ICON") != "" {
+		iconUrl = os.Getenv("SLACK_ICON")
+	} else {
+		iconUrl = "https://raw.githubusercontent.com/Issif/falcosidekick/master/imgs/falcosidekick.png"
+	}
+
 	slackPayload := slackPayload{
 		Username:    "Falco Sidekick",
-		IconURL:     "https://raw.githubusercontent.com/Issif/falcosidekick/master/imgs/falcosidekick.png",
+		IconURL:     iconUrl,
 		Attachments: attachments}
 
 	return slackPayload


### PR DESCRIPTION
- new Slack Options `SLACK_FOOTER`, `SLACK_ICON`
- check of `LISTEN_PORT` in `init()` : port is an integer between 1 and 65535
- Add output status in log to get those which are enabled
-- Fixed :
-  add some log level tags